### PR TITLE
Added required command to run after adding configs in iOS

### DIFF
--- a/docs/INSTALL-IOS-RNPM.md
+++ b/docs/INSTALL-IOS-RNPM.md
@@ -51,15 +51,6 @@ To open your project in XCode, use the file `YourProject.xcworkspace` (**not** `
 
 ```
 
-### **`Google-Services-Info.plist`**
-
-:warning: **NOTE:** If you've already installed `react-native-firebase`, this step will already have been performed.
-
-From your **Firebase Console**, copy your downloaded `Google-Services-Info.plist` file into your application:
-
-![](https://dl.dropboxusercontent.com/s/4s7kfa6quusqk7i/Google-Services.plist.png?dl=1)
-
-
 ### **`Run pod install`**
 
 :warning: **NOTE:**  If you've already installed `react-native-firebase`, this step will already have been performed.
@@ -69,6 +60,14 @@ After adding import to `AppDelegate.m` you need to install the new pod settings:
 cd ios
 pod install
 ```
+
+### **`Google-Services-Info.plist`**
+
+:warning: **NOTE:** If you've already installed `react-native-firebase`, this step will already have been performed.
+
+From your **Firebase Console**, copy your downloaded `Google-Services-Info.plist` file into your application:
+
+![](https://dl.dropboxusercontent.com/s/4s7kfa6quusqk7i/Google-Services.plist.png?dl=1)
 
 ### **`Issues?`**
 

--- a/docs/INSTALL-IOS-RNPM.md
+++ b/docs/INSTALL-IOS-RNPM.md
@@ -70,9 +70,9 @@ cd ios
 pod install
 ```
 
-### **`Issues`**
+### **`Issues?`**
 
 ```shell
 Undefined symbols for architecture armv7: “_OBJC_CLASS_$_FIRApp”
 ```
-During pod installation, you may see warnings related to `OTHER_LDFLAGS` or other flags. Select the target of your project and add `$(inherited)` flag in `Build Settings`. You can reference this [Stack Overflow issue](https://stackoverflow.com/questions/37344676/undefined-symbols-for-architecture-armv7-objc-class-firapp) for more details.
+During pod installation, you may see warnings related to `OTHER_LDFLAGS` or other flags. To fix the issue, select the target of your project and add `$(inherited)` flag in `Build Settings`. You can reference this [Stack Overflow issue](https://stackoverflow.com/questions/37344676/undefined-symbols-for-architecture-armv7-objc-class-firapp) for more details.

--- a/docs/INSTALL-IOS-RNPM.md
+++ b/docs/INSTALL-IOS-RNPM.md
@@ -69,7 +69,7 @@ From your **Firebase Console**, copy your downloaded `Google-Services-Info.plist
 
 ![](https://dl.dropboxusercontent.com/s/4s7kfa6quusqk7i/Google-Services.plist.png?dl=1)
 
-### **`Issues?`**
+### :x: **`Issues?`**
 
 ```shell
 Undefined symbols for architecture armv7: “_OBJC_CLASS_$_FIRApp”

--- a/docs/INSTALL-IOS-RNPM.md
+++ b/docs/INSTALL-IOS-RNPM.md
@@ -60,3 +60,19 @@ From your **Firebase Console**, copy your downloaded `Google-Services-Info.plist
 ![](https://dl.dropboxusercontent.com/s/4s7kfa6quusqk7i/Google-Services.plist.png?dl=1)
 
 
+### **`Run pod install`**
+
+:warning: **NOTE:**  If you've already installed `react-native-firebase`, this step will already have been performed.
+
+After adding import to `AppDelegate.m` you need to install the new pod settings:
+```shell
+cd ios
+pod install
+```
+
+### **`Issues`**
+
+```shell
+Undefined symbols for architecture armv7: “_OBJC_CLASS_$_FIRApp”
+```
+During pod installation, you may see warnings related to `OTHER_LDFLAGS` or other flags. Select the target of your project and add `$(inherited)` flag in `Build Settings`. You can reference this [Stack Overflow issue](https://stackoverflow.com/questions/37344676/undefined-symbols-for-architecture-armv7-objc-class-firapp) for more details.


### PR DESCRIPTION
After adding firebase configs to `AppDelegate.m` file, one needs to run `pod install` command. There was one issue that I encountered and added a fix I found that helped me to this doc as well.